### PR TITLE
RPI: 209-Migrate-gryphon-ivw-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "html-webpack-plugin": "^4.0.0",
-    "webpack": "^4.0.0"
+    "html-webpack-plugin": "^4.0.0 || ^5.0.0",
+    "webpack": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Updated peerDeps to support webpack 5, the one we are using in Gryphon IVW UI so no errors are raised when installing packages